### PR TITLE
Add threading design doc

### DIFF
--- a/README.org
+++ b/README.org
@@ -789,6 +789,14 @@ Ement.el is published in GNU ELPA and is considered part of GNU Emacs.  Therefor
 
 An Org-formatted version of the Matrix spec is available in the [[https://github.com/alphapapa/ement.el/tree/meta/spec][meta/spec]] branch.
 
+** Threaded replies design
+:PROPERTIES:
+:TOC:      :ignore (this)
+:END:
+
+See [[file:docs/threading-design.org][docs/threading-design.org]] for notes on adding thread support
+for replies using the Matrix \=`m.thread\=` relation.
+
 ** Rationale
 
 /This section is preserved for posterity.  As it says, Ement.el has long since surpassed ~matrix-client~, which should no longer be used./

--- a/docs/threading-design.org
+++ b/docs/threading-design.org
@@ -1,0 +1,43 @@
+#+TITLE: Threaded Replies Design
+#+AUTHOR: Ement.el
+#+OPTIONS: toc:nil num:nil
+
+* Overview
+
+Matrix 1.11 introduced a thread mechanism using a relation type \=`m.thread\=`.
+Each event in a thread references the *thread root* using this relation and may
+also include \=`m.in_reply_to\=` for the event it directly replies to. This
+section outlines how to extend Ement.el to support sending and displaying
+threaded replies.
+
+* Sending threaded messages
+
+- Extend ~ement-send-message~ and ~ement-room-send-message~ with an optional
+  ~thread-root-event~ argument.
+- When non-nil, compose the event content so that it includes
+  \=`m.relates_to\=` with:
+  - \=`rel_type: "m.thread"\=`
+  - \=`event_id\=` pointing to the thread root.
+  - \=`m.in_reply_to\=` referencing the immediate parent.
+- The existing quoting produced by ~ement--add-reply~ remains as fallback for
+  clients without thread support.
+
+* Tracking threads
+
+- Add a ~thread-root~ slot to ~ement-event~ to remember the root ID locally.
+- When receiving events, examine their \=`m.relates_to\=` value and fill the
+  slot. Events lacking this relation are displayed normally.
+
+* Viewing threads
+
+- New command ~ement-room-view-thread~ opens a buffer limited to events whose
+  ~thread-root~ slot matches the root at point.
+- In thread buffers, replies behave the same as in rooms but automatically carry
+  the thread root.
+
+* Compatibility notes
+
+- Threading should gracefully degrade for homeservers without MSC3440 support;
+  such messages will appear as regular rich replies.
+- Existing APIs remain backward compatible as the new argument defaults to nil.
+


### PR DESCRIPTION
## Summary
- outline how threads could be implemented using m.thread
- link the new design doc from the Development section

## Testing
- `make test` *(fails: emacs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840853c58b48325b8b130ed206dd87a